### PR TITLE
Add call stack parameter

### DIFF
--- a/src/Rollbar/MonadLogger.hs
+++ b/src/Rollbar/MonadLogger.hs
@@ -5,6 +5,8 @@ import BasicPrelude
 
 import Rollbar
 
+import GHC.Stack (CallStack)
+
 default (Text)
 
 
@@ -13,6 +15,7 @@ reportErrorS :: Settings
              -> Options
              -> Text -- ^ log section
              -> (Text -> Text -> IO ()) -- ^ monad-logger logging function. takes a section and a message
+             -> Maybe CallStack
              -> Text -- ^ message
              -> IO ()
 reportErrorS = reportLoggerErrorS


### PR DESCRIPTION
Add a call stack parameter. A consumer of the library could use e.g. `HasCallStack` from `GHC.Stack` to populate this value.
