### PR TITLE
Require ErrorLevel as argument

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                rollbar
-version:             2.1.1
+version:             2.2.0
 synopsis:            error tracking through rollbar.com
 homepage:            https://github.com/flipstone/rollbar-haskell
 license:             MIT
@@ -22,15 +22,14 @@ ghc-options:
 - -fno-warn-orphans
 dependencies:
   - base >=4.6 && < 5
-  - text >=1.2 && < 2.1
-  - aeson >=1.2 && < 2.2
+  - text >=1.2 && < 2.2
+  - aeson >=1.2 && < 2.3
   - vector >=0.12 && < 0.14
-  - network >=2.6 && < 3.2
+  - network >=2.6 && < 3.3
   - monad-control >=1.0.2 && < 1.0.4
   - resourcet >=1.1 && < 1.4
   - http-conduit >=2.2 && < 2.4
   - lifted-base == 0.2.3.*
-  - network-bsd == 2.8.*
 
 library:
   source-dirs: src

--- a/rollbar.cabal
+++ b/rollbar.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           rollbar
-version:        2.1.1
+version:        2.2.0
 synopsis:       error tracking through rollbar.com
 category:       Logging
 homepage:       https://github.com/flipstone/rollbar-haskell
@@ -27,14 +27,13 @@ library
       OverloadedStrings
   ghc-options: -Wall -Werror -Wcpp-undef -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -fno-warn-orphans
   build-depends:
-      aeson >=1.2 && <2.2
+      aeson >=1.2 && <2.3
     , base >=4.6 && <5
     , http-conduit >=2.2 && <2.4
     , lifted-base ==0.2.3.*
     , monad-control >=1.0.2 && <1.0.4
-    , network >=2.6 && <3.2
-    , network-bsd ==2.8.*
+    , network >=2.6 && <3.3
     , resourcet >=1.1 && <1.4
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
     , vector >=0.12 && <0.14
   default-language: Haskell2010

--- a/src/Rollbar/MonadLogger.hs
+++ b/src/Rollbar/MonadLogger.hs
@@ -13,6 +13,7 @@ reportErrorS ::
   -- | monad-logger logging function. takes a section and a message
   (T.Text -> T.Text -> IO ()) ->
   Maybe CallStack ->
+  Rollbar.ErrorLevel ->
   -- | message
   T.Text ->
   IO ()


### PR DESCRIPTION
The error level is very useful as Rollbar has different icons for the different messages, making it easier to filter/spot critical messages.

I also bumped bounds to make this compatible with newer libraries.

Tested with:

```
cabal build -w ghc-9.8.2 -c 'text>=2.1' -c 'network>=3.2' -c 'aeson>=2.2'
```

I removed the network-bsd dependency as it is used only for a type synonym, which is not worth the cost of having the dependency (which is unmaintained).
