### PR TITLE
Removes `ScopedTypeVariables` from `default-extensions`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -11,7 +11,6 @@ category:            Logging
 language: Haskell2010
 
 default-extensions:
-  - ScopedTypeVariables
   - ImportQualifiedPost
   - FlexibleContexts
 

--- a/rollbar.cabal
+++ b/rollbar.cabal
@@ -31,7 +31,6 @@ library
   hs-source-dirs:
       src
   default-extensions:
-      ScopedTypeVariables
       ImportQualifiedPost
       FlexibleContexts
   build-depends:

--- a/src/Rollbar.hs
+++ b/src/Rollbar.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Main entry point to the application.
 module Rollbar


### PR DESCRIPTION
This is extension is not considered stable, so we prefer to turn it on
where it is used rather than have it in `default-extensions`
